### PR TITLE
add missing "-"

### DIFF
--- a/examples/pinning/readme.md
+++ b/examples/pinning/readme.md
@@ -13,10 +13,10 @@ recursively by default.
 ```
 echo "ipfs rocks" > foo
 ipfs add foo
-ipfs pin ls -type=all
+ipfs pin ls --type=all
 ipfs pin rm <foo hash>
 ipfs pin rm -r <foo hash>
-ipfs pin ls -type=all
+ipfs pin ls --type=all
 ```
 
 As you may have noticed, the first `ipfs pin rm` command didnt work, it should


### PR DESCRIPTION
as a note, `ipfs pin ls -type=all` shows that argument parsing is trimming args wrong, need to check.

``` bash
» ipfs pin ls -type=all                                                    
Error: Invalid type 'ype=all', must be one of {direct, indirect, recursive, all}
Use 'ipfs pin ls --help' for information about this command
```
