### PR TITLE
ipns: Update publish messages to 'Published to <name>: <value>'

### DIFF
--- a/examples/ipns/readme.md
+++ b/examples/ipns/readme.md
@@ -15,7 +15,7 @@ note the hash that was output, and publish that hash out to the network:
 
 ```
 $ ipfs name publish <that hash>
-Published name <your peer ID> to <that hash>
+Published to <your peer ID>: <that hash>
 ```
 
 Now, to test that it worked, you could try a couple of different things:
@@ -43,7 +43,7 @@ $ echo "Look! Things have changed!" | ipfs add
 Next, take the hash from there and...
 ```
 $ ipfs name publish <the new hash>
-Published name <your peer ID> to <the new hash>
+Published to <your peer ID>: <the new hash>
 ```
 
 Viola! Now, if you resolve that entry again, you'll see your new object.


### PR DESCRIPTION
Catching up with ipfs/go-ipfs@e4447b3c (core/commands/publish: Fix
published message, 2015-05-07, ipfs/go-ipfs#1208, landed 2015-05-20
after v0.3.4).

We might want to put off merging this until the next go-ipfs release,
although I'm not sure what fraction of users are on tagged releases
vs. the go-ipfs master.
