### PR TITLE
Add restart setting to systemd example

### DIFF
--- a/examples/init/README.md
+++ b/examples/init/README.md
@@ -18,6 +18,7 @@ After=network.target
 
 [Service]
 ExecStart=/usr/bin/ipfs daemon
+Restart=on-failure
 
 [Install]
 WantedBy=multiuser.target


### PR DESCRIPTION
Given that the daemon crashes periodically (especially on a raspi2), and the fact we are going through the trouble to run the daemon through `systemd`, it would be better to take advantage of the process monitoring features by default.

Also, as it stands, this isn't starting up on system boot for some reason.  Still trying to understand what is going wrong.
