### PR TITLE
set window title to first h1 or h2

### DIFF
--- a/webapps/markdown-viewer/mdown
+++ b/webapps/markdown-viewer/mdown
@@ -47,6 +47,9 @@ function render(path) {
       .removeClass('navbar-fixed-top')
 
     $('#loading').hide()
+
+    // set window title to first h1 or h2 in markdown text
+    document.title = document.querySelector("h1, h2").textContent;
   })
 }
 


### PR DESCRIPTION
set window title to first h1 or h2. This does not affect the hard-coded
head title that appears in the top bar of the app, and therefore does
not affect metadata that is sucked into social network postings. It
probably also does not affect search/SEO.
