### PR TITLE
added optional Environmental variable for IPFS_PATH in systemd config

### DIFF
--- a/examples/init/README.md
+++ b/examples/init/README.md
@@ -15,7 +15,7 @@ For `systemd`, the best approach is to run the daemon in a user session. Here is
 Description=IPFS daemon
 
 [Service]
-# Environment=IPFS_PATH=/data/ipfs  # optional path to ipfs init directory if not default ($HOME/.ipfs)
+# Environment="IPFS_PATH=/data/ipfs"  # optional path to ipfs init directory if not default ($HOME/.ipfs)
 ExecStart=/usr/bin/ipfs daemon
 Restart=on-failure
 

--- a/examples/init/README.md
+++ b/examples/init/README.md
@@ -15,6 +15,7 @@ For `systemd`, the best approach is to run the daemon in a user session. Here is
 Description=IPFS daemon
 
 [Service]
+Environment=IPFS_PATH=/data/ipfs  # optional path to ipfs init directory if not default ($HOME/.ipfs)
 ExecStart=/usr/bin/ipfs daemon
 Restart=on-failure
 

--- a/examples/init/README.md
+++ b/examples/init/README.md
@@ -15,7 +15,7 @@ For `systemd`, the best approach is to run the daemon in a user session. Here is
 Description=IPFS daemon
 
 [Service]
-Environment=IPFS_PATH=/data/ipfs  # optional path to ipfs init directory if not default ($HOME/.ipfs)
+# Environment=IPFS_PATH=/data/ipfs  # optional path to ipfs init directory if not default ($HOME/.ipfs)
 ExecStart=/usr/bin/ipfs daemon
 Restart=on-failure
 


### PR DESCRIPTION
This may not apply to most, however, I have my ipfs init directory outside of $HOME ( in /data/ipfs ), therefore the instructions needed to be modified for systemd to have the appropriate environment variable for $IPFS_PATH, for me this is /data/ipfs rather than the default $HOME/.ipfs .. 
