### PR TITLE
change quotes used for publishable content

### DIFF
--- a/examples/ipns/readme.md
+++ b/examples/ipns/readme.md
@@ -8,7 +8,7 @@ are quite simple.
 First, you'll need some content to publish:
 
 ```
-$ echo 'Let\'s have some mutable fun!' | ipfs add
+$ echo "Let's have some mutable fun!" | ipfs add
 ```
 
 Note the hash that was printed out, and use it here to publish it to the network:


### PR DESCRIPTION
Single quote strings are literal strings (per posix), so no escaping ever happens within the strings. The example was non-functioning if anyone wanted to play along at home.