### PR TITLE
Update readme.md

### DIFF
--- a/examples/api/demoapp/readme.md
+++ b/examples/api/demoapp/readme.md
@@ -54,10 +54,6 @@ func SetupIpfs() (*core.IpfsNode, error) {
 		Online: true,
 	}
 
-	cfg := new(core.BuildCfg)
-	cfg.Repo = r
-	cfg.Online = true
-
 	return core.NewNode(context.Background(), cfg)
 }
 ```


### PR DESCRIPTION
The current examples/api/demoapp documentation has an error where it defines `cfg` twice using two different styles:
```
	cfg := &core.BuildCfg{
		Repo:   r,
		Online: true,
	}

	cfg := new(core.BuildCfg)
	cfg.Repo = r
	cfg.Online = true
```
This PR will make the documentation more consistent with the actual code.